### PR TITLE
Fixed bug where employees can have duplicated mails

### DIFF
--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -1,4 +1,4 @@
 class Employee < ApplicationRecord
-  validates :full_name, :email, :position, presence: true
-  validates :personal_id, presence: true, uniqueness: true
+  validates :full_name, :position, presence: true
+  validates :personal_id, :email, presence: true, uniqueness: true
 end

--- a/db/migrate/20220602043856_add_uniqueness_constraint_to_employees_email.rb
+++ b/db/migrate/20220602043856_add_uniqueness_constraint_to_employees_email.rb
@@ -1,0 +1,5 @@
+class AddUniquenessConstraintToEmployeesEmail < ActiveRecord::Migration[6.0]
+  def change
+    add_index :employees, :email, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_01_074536) do
+ActiveRecord::Schema.define(version: 2022_06_02_043856) do
 
   create_table "employees", force: :cascade do |t|
     t.string "full_name"
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2022_06_01_074536) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "city"
     t.string "country"
+    t.index ["email"], name: "index_employees_on_email", unique: true
   end
 
 end

--- a/spec/factories/employees.rb
+++ b/spec/factories/employees.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :employee do
     full_name { "MyString" }
     sequence(:personal_id) { |n| "MyString#{n}" }
-    email { "MyString" }
+    sequence(:email) { |n| "MyString#{n}" }
     position { "MyString" }
     salary { 1 }
     city { "MyString" }

--- a/spec/requests/api/exposed/v1/employees_spec.rb
+++ b/spec/requests/api/exposed/v1/employees_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe 'Api::Exposed::V1::EmployeesControllers', type: :request do
       JSON.parse(response.body)['employee'].symbolize_keys
     end
 
+
     def perform
       post '/api/v1/employees', params: params
     end
@@ -50,6 +51,11 @@ RSpec.describe 'Api::Exposed::V1::EmployeesControllers', type: :request do
 
     it { expect(attributes).to include(params[:employee]) }
     it { expect(response.status).to eq(201) }
+    it "can't create employee with duplicate email" do
+      params[:employee][:personal_id] = 'Some non-duplicated personal_id'
+      perform
+      expect(response.status).to eq(400)
+    end
   end
 
   describe 'GET /show' do


### PR DESCRIPTION
Please, check the issue information and diagnosis in [issue 2](https://github.com/lautarograc/backend-test-nala/issues/3)  
  
Changes made:  
Validated uniqueness of email in both the model and the database. (note: it's usually good practice to include validations both in the database and in the model to avoid unsync of data between the models and the DB, validations in the client-side should also be included to avoid wasting resources)  
Fixed factory to reflect the new validation.  
Tested for error code when creating an employee with a duplicated email.