### PR TITLE
added a feature to include staths for employees

### DIFF
--- a/app/controllers/api/exposed/v1/employees_controller.rb
+++ b/app/controllers/api/exposed/v1/employees_controller.rb
@@ -35,6 +35,7 @@ class Api::Exposed::V1::EmployeesController < Api::Exposed::V1::BaseController
       :salary,
       :city,
       :country,
+      :status,
       :active,
       :starting_date
     )

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -1,4 +1,5 @@
 class Employee < ApplicationRecord
   validates :full_name, :position, presence: true
   validates :personal_id, :email, presence: true, uniqueness: true
+  validates :status, inclusion: { in: %w[probationary regular inactive], message: '%{value} is not a valid status' }
 end

--- a/app/serializers/api/exposed/v1/employee_serializer.rb
+++ b/app/serializers/api/exposed/v1/employee_serializer.rb
@@ -10,6 +10,7 @@ class Api::Exposed::V1::EmployeeSerializer < ActiveModel::Serializer
     :salary,
     :city,
     :country,
+    :status,
     :active,
     :starting_date,
     :created_at,

--- a/db/migrate/20220602052913_add_status_to_employees.rb
+++ b/db/migrate/20220602052913_add_status_to_employees.rb
@@ -1,0 +1,5 @@
+class AddStatusToEmployees < ActiveRecord::Migration[6.0]
+  def change
+    add_column :employees, :status, :string, default: 'regular'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_02_043856) do
+ActiveRecord::Schema.define(version: 2022_06_02_052913) do
 
   create_table "employees", force: :cascade do |t|
     t.string "full_name"
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2022_06_02_043856) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "city"
     t.string "country"
+    t.string "status", default: "regular"
     t.index ["email"], name: "index_employees_on_email", unique: true
   end
 

--- a/spec/factories/employees.rb
+++ b/spec/factories/employees.rb
@@ -9,5 +9,6 @@ FactoryBot.define do
     country { "MyString" }
     active { false }
     starting_date { "MyString" }
+    status { "probationary" }
   end
 end

--- a/spec/requests/api/exposed/v1/employees_spec.rb
+++ b/spec/requests/api/exposed/v1/employees_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe 'Api::Exposed::V1::EmployeesControllers', type: :request do
           salary: 666,
           city: 'Some city',
           country: 'Some country',
+          status: 'probationary',
           active: true,
           starting_date: 'Some starting_date'
         }
@@ -53,6 +54,11 @@ RSpec.describe 'Api::Exposed::V1::EmployeesControllers', type: :request do
     it { expect(response.status).to eq(201) }
     it "can't create employee with duplicate email" do
       params[:employee][:personal_id] = 'Some non-duplicated personal_id'
+      perform
+      expect(response.status).to eq(400)
+    end
+    it "can't create employee with unvalid status" do
+      params[:employee][:status] = 'non-valid'
       perform
       expect(response.status).to eq(400)
     end


### PR DESCRIPTION
Steps to address this problem described in [issue 3](https://github.com/lautarograc/backend-test-nala/issues/5)  
  
Changes made:  
Created a new migration adding status to the employee table  
Permitted the new parameter inside the controller  
Added a validation inside the model to whitelist only intended values as valid status  
Added a status attribute to the factory of employees  
Tested in the request spec to see that 1. POST requests sent with a valid status are received with a succesful 201 status code and 2. POST requests sent with unvalid status are received with a 400 status code